### PR TITLE
Docs/teachers module

### DIFF
--- a/src/pages/backend/collections/teachers/index.md
+++ b/src/pages/backend/collections/teachers/index.md
@@ -7,18 +7,20 @@ Armazena os dados dos professores da academia, incluindo informações pessoais,
 
 ## Estrutura dos Campos
 
-| Campo        | Tipo de Dado                                  | Obrigatório              | Valor Padrão | Descrição                                                                   |
-| ------------ | --------------------------------------------- | ------------------------ | -------------------- | --------------------------------------------------------------------------- |
-| `_id`        | ObjectId                                      | Sim                      | Gerado pelo MongoDB  | Identificador único do professor                                            |
-| `name`       | String                                        | Sim                      | —                    | Nome completo do professor                                                  |
-| `cpf`        | String (11 caracteres, único)                 | Sim                      | —                    | CPF do professor, deve ser único e ter exatamente 11 caracteres             |
-| `email`      | String (único, formato email válido)          | Sim                      | —                    | Endereço de e-mail único e válido                                           |
-| `image`      | Buffer                                        | Sim                      | —                    | Arquivo da imagem ilustrativa da turma armazenado em formato binário (Buffer)                                         |
-| `hourPrice`  | Number                                        | Sim                      | —                    | Valor cobrado por hora/aula, formato numérico                               |
-| `modalities` | Array de ObjectId (referência a `modalities`) | Sim (validação mínimo 1) | —                    | Lista das modalidades que o professor está habilitado a ministrar           |
-| `status`     | Boolean                                       | Sim                      | `true`               | Indica se o professor está ativo (`true`) ou inativo (`false`)              |
-| `createdAt`  | Date                                          | Sim                      | Data atual           | Data de criação do registro (automático pelo `timestamps: true`)            |
-| `updatedAt`  | Date                                          | Sim                      | Data atual           | Data da última atualização do registro (automático pelo `timestamps: true`) |
+| Campo         | Tipo de Dado                                  | Obrigatório    | Valor Padrão        | Descrição                                                                   |
+| ------------- | --------------------------------------------- | -------------- | ------------------- | --------------------------------------------------------------------------- |
+| `_id`         | ObjectId                                      | Sim            | Gerado pelo MongoDB | Identificador único do professor                                            |
+| `name`        | String                                        | Sim            | —                   | Nome completo do professor                                                  |
+| `cpf`         | String (11 caracteres, único)                 | Sim            | —                   | CPF do professor, deve ser único e ter exatamente 11 caracteres             |
+| `email`       | String (único, formato email válido)          | Sim            | —                   | Endereço de e-mail único e válido                                           |
+| `description` | String                                        | Sim            | —                   | Breve descrição sobre o professor                                           |
+| `image`       | Buffer                                        | Sim            | —                   | Arquivo da imagem do professor armazenado em formato binário (Buffer)       |
+| `hourPrice`   | Number                                        | Sim            | —                   | Valor cobrado por hora/aula                                                 |
+| `modalities`  | Array de ObjectId (referência a `Modalities`) | Sim (mínimo 1) | —                   | Lista das modalidades que o professor está habilitado a ministrar           |
+| `status`      | Boolean                                       | Sim            | `true`              | Indica se o professor está ativo (`true`) ou inativo (`false`)              |
+| `createdAt`   | Date                                          | Sim            | Data atual          | Data de criação do registro (automático pelo `timestamps: true`)            |
+| `updatedAt`   | Date                                          | Sim            | Data atual          | Data da última atualização do registro (automático pelo `timestamps: true`) |
+
 
 ## Relacionamentos
 
@@ -42,6 +44,7 @@ Armazena os dados dos professores da academia, incluindo informações pessoais,
   "name": "Carlos Eduardo",
   "cpf": "12345678901",
   "email": "carlos.eduardo@example.com",
+  "description": "Faixa Preta 3º Dan. Com mais de 15 anos de experiência no judô...",
   "image": "https://exemplo.com/fotos/carlos.jpg",
   "hourPrice": 70.0,
   "modalities": [

--- a/src/pages/backend/modules/teachers/deactivate/index.md
+++ b/src/pages/backend/modules/teachers/deactivate/index.md
@@ -1,0 +1,81 @@
+[< Back](../)
+
+# Desativar professor
+Este endpoint permite que **administradores autenticados** com `role` **admin** desativem um professor na academia, tornando-o indisponível para vinculação em turmas e demais funcionalidades do sistema.
+
+## Método HTTP
+
+`PATCH`
+
+## URL
+
+`api/v1/teachers/deactivate/:id`
+
+## Autenticação
+- **Tipo:** JWT via Cookie
+- **Nível de permissão:** Apenas usuários com `role: admin`
+
+## Parâmetros da Requisição
+### URL Parameters
+
+| Campo | Tipo   | Obrigatório | Validação            | Exemplo                      |
+| ----- | ------ | ----------- | -------------------- | ---------------------------- |
+| id    | string | Sim         | ID válido do MongoDB | `"66b9d4e1a0f3e6c4f4a21c8e"` |
+
+**Exemplo de URL:**
+```
+PATCH /api/v1/teachers/deactivate/66b9d4e1a0f3e6c4f4a21c8e
+```
+
+## Resposta de Sucesso
+**Status:** `200 OK`
+
+```json
+{
+  "data": "Teacher successfully deactivate"
+}
+```
+
+## Respostas de Erro
+**Status:** `400 Bad Request` — ID inválido ou professor vinculado a turmas ativas
+
+```json
+{
+  "statusCode": 400,
+  "message": [
+    "Invalid id format",
+    "Teacher is registered in active classes"
+  ],
+  "error": "Bad Request"
+}
+```
+
+**Status:** `401 Unauthorized` — Token JWT ausente ou inválido
+```json
+{
+  "statusCode": 401,
+  "message": "Unauthorized"
+}
+```
+
+**Status:** `403 Forbidden` — Usuário não tem permissão (role diferente de `admin`)
+```json
+{
+  "statusCode": 403,
+  "message": "Forbidden resource"
+}
+```
+
+**Status:** `404 Not Found` — Professor não encontrado
+```json
+{
+  "statusCode": 404,
+  "message": "Teacher with id 66b9d4e1a0f3e6c4f4a21c8e not found"
+}
+```
+
+## Observações
+- Ao **desativar** um professor, ele **não** poderá mais ser vinculado a novas turmas
+- Antes da desativação, é verificado se o professor não possui nenhuma turma ativa vinculada
+- Máximo de **10 requisições por minuto** por administrador
+- Autenticação via **token JWT** armazenado em **cookie HTTP-only**

--- a/src/pages/backend/modules/teachers/find-all-teachers/index.md
+++ b/src/pages/backend/modules/teachers/find-all-teachers/index.md
@@ -1,0 +1,108 @@
+[< Back](../)
+
+# Listar professores com paginação e filtros
+Este endpoint permite que **administradores autenticados** com `role` **admin** listem todos os professores cadastrados na academia com informações detalhadas dos professores. Usuários sem permissão de admin recebem apenas dados públicos dos professores. É possível aplicar filtros por `status`, `month (mês)` e `year (ano)` e paginar os resultados.
+
+## Método HTTP
+`GET`
+
+## URL
+`api/v1/teachers`
+
+## Autenticação
+- **Tipo:** JWT via Cookie
+- **Nível de permissão:** Apenas usuários com `role: admin` recebem informações pessoais completas
+
+## Parâmetros da Requisição
+
+### Query Parameters
+
+| Campo  | Tipo    | Obrigatório | Validação                           | Exemplo |
+| ------ | ------- | ----------- | ----------------------------------- | ------- |
+| skip   | number  | Sim         | Número de documentos a pular        | 0       |
+| limit  | number  | Sim         | Número de documentos a retornar     | 10      |
+| status | boolean | Não         | Filtrar professores ativos/inativos | true    |
+| month  | number  | Não         | 1 a 12, mês da carga horária        | 8       |
+| year   | number  | Não         | Ano da carga horária                | 2025    |
+
+**Exemplo de URL:**
+```
+GET /api/v1/teachers?skip=0&limit=10&status=true&month=8&year=2025
+```
+
+## Respostas de Sucesso
+### Usuário autenticado
+**Status:** `200 OK`
+
+```json
+{
+  "data": [
+    {
+      "teacher": {
+        "_id": "66b9d4e1a0f3e6c4f4a21c8e",
+        "name": "Marcos Silva",
+        "cpf": "12345678910",
+        "email": "marcossilva@gmail.com",
+        "hourPrice": 5,
+        "description": "Faixa Preta 3º Dan. Com mais de 15 anos de experiência no judô.",
+        "modalities": [
+          {
+            "name": "Judô",
+            "description": "O Judô é uma arte marcial de origem japonesa",
+            "status": true
+          }
+        ],
+        "image": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABA..."
+      },
+      "report": {
+        "workload": "40:00",
+        "salary": "200,00",
+        "month": 8,
+        "year": 2025
+      }
+    }
+  ],
+  "pagination": {
+    "skip": 0,
+    "limit": 10
+  },
+  "total": 1
+}
+```
+
+### Qualquer usuário
+**Status:** `200 OK`
+
+```json
+{
+  "data": [
+    {
+      "teacher": {
+        "_id": "66b9d4e1a0f3e6c4f4a21c8e",
+        "name": "Marcos Silva",
+        "description": "Faixa Preta 3º Dan. Com mais de 15 anos de experiência no judô.",
+        "modalities": [
+          {
+            "name": "Judô",
+            "description": "O Judô é uma arte marcial de origem japonesa",
+            "status": true
+          }
+        ],
+        "image": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABA..."
+      },
+    }
+  ],
+  "pagination": {
+    "skip": 0,
+    "limit": 10
+  },
+  "total": 1
+}
+```
+
+## Observações
+- Máximo de **20 requisições por minuto** por IP
+- Para usuários não-admin, apenas os campos públicos (`name`, `description`, `image`) são retornados
+- Para usuários admin, inclui **carga horária mensal** e **gasto mensal** para cada professor
+- Paginação aplicada via `skip` e `limit`
+- Filtro opcional por `status` (ativo/inativo)

--- a/src/pages/backend/modules/teachers/find-teacher-by-id/index.md
+++ b/src/pages/backend/modules/teachers/find-teacher-by-id/index.md
@@ -1,0 +1,115 @@
+[< Back](../)
+
+# Buscar professor por ID
+Este endpoint permite que **administradores autenticados** com `role` **admin** consultem informações detalhadas de um professor específico. Usuários sem permissão de admin recebem apenas dados públicos do professor.
+
+## Método HTTP
+`GET`
+
+## URL
+`api/v1/teachers/id/:id`
+
+## Autenticação
+
+- **Tipo:** JWT via Cookie
+- **Nível de permissão:** Apenas usuários com `role: admin` recebem informações pessoais completas
+
+## Parâmetros da Requisição
+
+### URL Parameters
+| Campo | Tipo   | Obrigatório | Validação            | Exemplo                      |
+| ----- | ------ | ----------- | -------------------- | ---------------------------- |
+| id    | string | Sim         | ID válido do MongoDB | `"66b9d4e1a0f3e6c4f4a21c8e"` |
+
+### Query Parameters
+| Campo | Tipo   | Obrigatório | Validação                    | Exemplo |
+| ----- | ------ | ----------- | ---------------------------- | ------- |
+| month | number | Não         | 1 a 12, mês da carga horária | 8       |
+| year  | number | Não         | Ano da carga horária         | 2025    |
+
+**Exemplo de URL:**
+```
+GET /api/v1/teachers/id/66b9d4e1a0f3e6c4f4a21c8e?month=8&year=2025
+```
+
+## Respostas de Sucesso
+### Usuário autenticado
+**Status:** `200 OK`
+
+```json
+{
+  "data": {
+    "teacher": {
+      "_id": "66b9d4e1a0f3e6c4f4a21c8e",
+      "name": "Marcos Silva",
+      "cpf": "12345678910",
+      "email": "marcossilva@gmail.com",
+      "hourPrice": 5,
+      "description": "Faixa Preta 3º Dan. Com mais de 15 anos de experiência no judô.",
+      "modalities": [
+        {
+          "name": "Judô",
+          "description": "O Judô é uma arte marcial de origem japonesa",
+          "status": true
+        }
+      ],
+      "image": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABA..."
+    },
+    "report": {
+      "workload": "40:00",
+      "salary": "200,00",
+      "month": 8,
+      "year": 2025
+    }
+  }
+}
+```
+
+### Qualquer usuário
+**Status:** `200 OK`
+
+```json
+{
+  "data": {
+    "teacher": {
+      "_id": "66b9d4e1a0f3e6c4f4a21c8e",
+      "name": "Marcos Silva",
+      "description": "Faixa Preta 3º Dan. Com mais de 15 anos de experiência no judô.",
+      "modalities": [
+        {
+          "name": "Judô",
+          "description": "O Judô é uma arte marcial de origem japonesa",
+          "status": true
+        }
+      ],
+      "image": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABA..."
+    },
+  }
+}
+```
+
+## Respostas de Erro
+
+**Status:** `400 Bad Request` — ID inválido
+
+```json
+{
+  "statusCode": 400,
+  "message": "Invalid id format",
+  "error": "Bad Request"
+}
+```
+
+**Status:** `404 Not Found` — Professor não encontrado
+
+```json
+{
+  "statusCode": 404,
+  "message": "Teacher with id 66b9d4e1a0f3e6c4f4a21c8e not found"
+}
+```
+
+## Observações
+- Máximo de **20 requisições por minuto** por IP
+- Para usuários não-admin, apenas os campos públicos (`name`, `description`, `image`) são retornados
+- Para usuários admin, inclui **carga horária mensal** e **gasto mensal**

--- a/src/pages/backend/modules/teachers/index.md
+++ b/src/pages/backend/modules/teachers/index.md
@@ -4,3 +4,9 @@
 
 ## [Cadastrar novo professor](../../../backend/modules/teachers/create-teacher/)
 Este endpoint permite que **administradores autenticados** com `role` **admin** cadastrem um novo professor na academia. Cada professor contém informações pessoais, incluindo imagem de perfil obrigatória. A imagem enviada é processada, armazenada no banco de dados como **Buffer** e convertida para **Base64** na resposta.
+
+## [Buscar professor por ID](../../../backend/modules/teachers/find-teacher-by-id/)
+Este endpoint permite que **administradores autenticados** com `role` **admin** consultem informações detalhadas de um professor específico. Usuários sem permissão de admin recebem apenas dados públicos do professor.
+
+## [Listar professores com paginação e filtros](../../../backend/modules/teachers/find-all-teachers/)
+Este endpoint permite que **administradores autenticados** com `role` **admin** listem todos os professores cadastrados na academia com informações detalhadas dos professores. Usuários sem permissão de admin recebem apenas dados públicos dos professores. É possível aplicar filtros por `status`, `month (mês)` e `year (ano)` e paginar os resultados.

--- a/src/pages/backend/modules/teachers/index.md
+++ b/src/pages/backend/modules/teachers/index.md
@@ -11,6 +11,9 @@ Este endpoint permite que **administradores autenticados** com `role` **admin** 
 ## [Listar professores com paginação e filtros](../../../backend/modules/teachers/find-all-teachers/)
 Este endpoint permite que **administradores autenticados** com `role` **admin** listem todos os professores cadastrados na academia com informações detalhadas dos professores. Usuários sem permissão de admin recebem apenas dados públicos dos professores. É possível aplicar filtros por `status`, `month (mês)` e `year (ano)` e paginar os resultados.
 
+## [Buscar 5 principais professores](../../../backend/modules/teachers/top-5-teachers/)
+Este endpoint retorna os **5 professores** que estão presentes no maior número de turmas cadastradas no sistema.
+
 ## [Atualizar professor](../../../backend/modules/teachers/update-teacher/)
 Este endpoint permite que **administradores autenticados** com `role` **admin** atualizem parcialmente ou totalmente os dados de um professor já cadastrado na academia. O sistema realiza validações de CPF, e-mail, modalidades ativas e compatibilidade com turmas em andamento.
 

--- a/src/pages/backend/modules/teachers/index.md
+++ b/src/pages/backend/modules/teachers/index.md
@@ -14,6 +14,9 @@ Este endpoint permite que **administradores autenticados** com `role` **admin** 
 ## [Buscar 5 principais professores](../../../backend/modules/teachers/top-5-teachers/)
 Este endpoint retorna os **5 professores** que estão presentes no maior número de turmas cadastradas no sistema.
 
+## [Gerar relatório dos professores](../../../backend/modules/teachers/teachers-report/)
+Este endpoint permite que **administradores autenticados** com `role` **admin** gerem um relatório de todos os professores cadastrados no sistema, exportando os dados em **PDF**.
+
 ## [Atualizar professor](../../../backend/modules/teachers/update-teacher/)
 Este endpoint permite que **administradores autenticados** com `role` **admin** atualizem parcialmente ou totalmente os dados de um professor já cadastrado na academia. O sistema realiza validações de CPF, e-mail, modalidades ativas e compatibilidade com turmas em andamento.
 

--- a/src/pages/backend/modules/teachers/index.md
+++ b/src/pages/backend/modules/teachers/index.md
@@ -13,3 +13,9 @@ Este endpoint permite que **administradores autenticados** com `role` **admin** 
 
 ## [Atualizar professor](../../../backend/modules/teachers/update-teacher/)
 Este endpoint permite que **administradores autenticados** com `role` **admin** atualizem parcialmente ou totalmente os dados de um professor já cadastrado na academia. O sistema realiza validações de CPF, e-mail, modalidades ativas e compatibilidade com turmas em andamento.
+
+## [Desativar professor](../../../backend/modules/teachers/deactivate/)
+Este endpoint permite que **administradores autenticados** com `role` **admin** desativem um professor na academia, tornando-o indisponível para vinculação em turmas e demais funcionalidades do sistema.
+
+## [Reativar professor](../../../backend/modules/teachers/reactivate/)
+Este endpoint permite que **administradores autenticados** com `role` **admin** reativem um professor previamente inativado, tornando-o disponível para vinculação em turmas e demais funcionalidades do sistema.

--- a/src/pages/backend/modules/teachers/index.md
+++ b/src/pages/backend/modules/teachers/index.md
@@ -10,3 +10,6 @@ Este endpoint permite que **administradores autenticados** com `role` **admin** 
 
 ## [Listar professores com paginação e filtros](../../../backend/modules/teachers/find-all-teachers/)
 Este endpoint permite que **administradores autenticados** com `role` **admin** listem todos os professores cadastrados na academia com informações detalhadas dos professores. Usuários sem permissão de admin recebem apenas dados públicos dos professores. É possível aplicar filtros por `status`, `month (mês)` e `year (ano)` e paginar os resultados.
+
+## [Atualizar professor](../../../backend/modules/teachers/update-teacher/)
+Este endpoint permite que **administradores autenticados** com `role` **admin** atualizem parcialmente ou totalmente os dados de um professor já cadastrado na academia. O sistema realiza validações de CPF, e-mail, modalidades ativas e compatibilidade com turmas em andamento.

--- a/src/pages/backend/modules/teachers/reactivate/index.md
+++ b/src/pages/backend/modules/teachers/reactivate/index.md
@@ -1,0 +1,74 @@
+[< Back](../)
+
+# Reativar professor
+Este endpoint permite que **administradores autenticados** com `role` **admin** reativem um professor previamente inativado, tornando-o disponível para vinculação em turmas e demais funcionalidades do sistema.
+
+## Método HTTP
+`PATCH`
+
+## URL
+`api/v1/teachers/reactivate/:id`
+
+## Autenticação
+- **Tipo:** JWT via Cookie
+- **Nível de permissão:** Apenas usuários com `role: admin`
+
+## Parâmetros da Requisição
+### URL Parameters
+
+| Campo | Tipo   | Obrigatório | Validação            | Exemplo                      |
+| ----- | ------ | ----------- | -------------------- | ---------------------------- |
+| id    | string | Sim         | ID válido do MongoDB | `"66b9d4e1a0f3e6c4f4a21c8e"` |
+
+**Exemplo de URL:**
+```
+PATCH /api/v1/teachers/reactivate/66b9d4e1a0f3e6c4f4a21c8e
+```
+
+## Resposta de Sucesso
+**Status:** `200 OK`
+
+```json
+{
+  "data": "Teacher successfully reactivate"
+}
+```
+
+## Respostas de Erro
+**Status:** `400 Bad Request` — ID inválido
+```json
+{
+  "statusCode": 400,
+  "message": "Invalid id format",
+  "error": "Bad Request"
+}
+```
+
+**Status:** `401 Unauthorized` — Token JWT ausente ou inválido
+```json
+{
+  "statusCode": 401,
+  "message": "Unauthorized"
+}
+```
+
+**Status:** `403 Forbidden` — Usuário não tem permissão (role diferente de `admin`)
+```json
+{
+  "statusCode": 403,
+  "message": "Forbidden resource"
+}
+```
+
+**Status:** `404 Not Found` — Professor não encontrado
+```json
+{
+  "statusCode": 404,
+  "message": "Teacher with id 66b9d4e1a0f3e6c4f4a21c8e not found"
+}
+```
+
+## Observações
+- Máximo de **10 requisições por minuto** por administrador
+- Reativação apenas altera o status do professor para **ativo**
+- Autenticação via **token JWT** armazenado em **cookie HTTP-only**

--- a/src/pages/backend/modules/teachers/teachers-report/index.md
+++ b/src/pages/backend/modules/teachers/teachers-report/index.md
@@ -1,0 +1,98 @@
+[< Back](../)
+
+# Gerar relatório dos professores
+Este endpoint permite que **administradores** gerem um relatório de todos os professores cadastrados no sistema, exportando os dados em **PDF**.
+
+O relatório contém:
+- Informações pessoais (`name`, `cpf`, `email`)
+- Modalidades disponíveis
+- Quantidade de turmas vinculadas
+- Valor da hora/aula (`hourPrice`)
+- Carga horária mensal
+- Salário mensal (`carga horária × valor da hora/aula`)
+- Data de cadastro
+- Indicadores:
+  - Total de professores ativos
+  - Gastos totais
+  - Média do valor/hora
+  - Média de carga horária
+  - Média salarial
+  - Professor com mais aulas
+  - Professor com menos aulas
+  - Evolução de custos em relação ao mês anterior
+
+## Método HTTP
+
+`GET`
+
+## URL
+
+`api/v1/teachers/report`
+
+## Autenticação
+- **Tipo:** JWT via Cookie
+- **Nível de permissão:** Apenas usuários com `role: admin`
+
+## Resposta de Sucesso
+
+**Status:** `200 OK`
+
+```json
+{
+  "data": {
+    "filename": "teachers-report.pdf",
+    "mimeType": "application/pdf",
+    "file": "data:application/pdf;base64,JVBERi0xLjUKJ..."
+  }
+}
+```
+
+- `filename`: nome do arquivo PDF gerado
+- `mimeType`: tipo do arquivo (sempre `application/pdf`)
+- `file`: conteúdo do relatório em base64 (pode ser convertido de volta para PDF)
+
+## Respostas de Erro
+
+**Status:** `400 Bad Request` — Erro de validação ou dados inconsistentes
+
+```json
+{
+  "statusCode": 400,
+  "message": "Invalid data for report generation",
+  "error": "Bad Request"
+}
+```
+
+**Status:** `401 Unauthorized` — Token JWT ausente ou inválido
+
+```json
+{
+  "statusCode": 401,
+  "message": "Unauthorized"
+}
+```
+
+**Status:** `403 Forbidden` — Usuário não tem permissão (role diferente de `admin`)
+
+```json
+{
+  "statusCode": 403,
+  "message": "Forbidden resource",
+  "error": "Forbidden"
+}
+```
+
+**Status:** `429 Too Many Requests` — Limite de requisições atingido
+
+```json
+{
+  "statusCode": 429,
+  "message": "Too many requests, please try again later.",
+  "error": "Too Many Requests"
+}
+```
+
+## Observações
+- Limite máximo de requisições **10 por minuto** por administrador
+- O relatório é gerado a partir de um **template Handlebars** (`teacher-report.hbs`) convertido em PDF via **Puppeteer**
+- Conteúdo do relatório em base64

--- a/src/pages/backend/modules/teachers/top-5-teachers/index.md
+++ b/src/pages/backend/modules/teachers/top-5-teachers/index.md
@@ -1,0 +1,87 @@
+[< Back](../)
+
+# Buscar 5 principais professores
+Este endpoint retorna os **5 professores** que estão presentes no maior número de turmas cadastradas no sistema.
+
+## Método HTTP
+`GET`
+
+## URL
+`api/v1/teachers/top-five`
+
+## Autenticação
+- **Tipo:** Nenhuma
+- **Acesso:** Qualquer usuário pode utilizar este endpoint
+
+## Parâmetros da Requisição
+Nenhum parâmetro é necessário.
+
+## Resposta de Sucesso
+
+**Status:** `200 OK`
+
+```json
+{
+  "data": [
+    {
+      "teacher": {
+        "name": "Marcos Silva",
+        "description": "Faixa Preta 3º Dan. Com mais de 15 anos de experiência no judô.",
+        "modalities": [
+            {
+            "name": "Judô",
+            "description": "O Judô é uma arte marcial de origem japonesa",
+            "status": true
+            }
+        ],
+        "image": "https://cdn.academia.com/images/teacher1.png"
+      },
+      "totalClasses": 12
+    },
+    {
+      "teacher": {
+        "name": "Ana Souza",
+        "description": "Especialista em Muay Thai, formada na Tailândia.",
+        "modalities": [
+            {
+            "name": "Judô",
+            "description": "O Judô é uma arte marcial de origem japonesa",
+            "status": true
+            }
+        ],
+        "image": "https://cdn.academia.com/images/teacher2.png"
+      },
+      "totalClasses": 10
+    }
+  ]
+}
+```
+
+- `teacher`: objeto contendo apenas `name`, `description`, `modalities` e `image`
+- `totalClasses`: quantidade de turmas ativas em que o professor está vinculado
+
+## Respostas de Erro
+
+**Status:** `200 OK` — Nenhum professor encontrado
+
+```json
+{
+  "data": []
+}
+```
+
+**Status:** `429 Too Many Requests` — Limite de requisições atingido
+
+```json
+{
+  "statusCode": 429,
+  "message": "Too many requests, please try again later.",
+  "error": "Too Many Requests"
+}
+```
+
+## Observações
+- Limite máximo de **30 requisições por minuto** por usuário
+- Apenas professores com **status ativo** são considerados
+- Caso não existam professores ou turmas ativas, retorna um array vazio
+- Caso existam **menos de 5 professores**, serão retornados apenas os disponíveis

--- a/src/pages/backend/modules/teachers/update-teacher/index.md
+++ b/src/pages/backend/modules/teachers/update-teacher/index.md
@@ -1,0 +1,151 @@
+[< Back](../)
+
+# Atualizar professor
+Este endpoint permite que **administradores autenticados** com `role` **admin** atualizem parcialmente ou totalmente os dados de um professor já cadastrado na academia. Todos os campos obrigatórios e opcionais podem ser modificados, incluindo imagem de perfil e modalidades associadas. O sistema realiza validações de CPF, e-mail, modalidades ativas e compatibilidade com turmas em andamento.
+
+## Método HTTP
+`PATCH`
+
+## URL
+`api/v1/teachers/:id`
+
+## Autenticação
+- **Tipo:** JWT via Cookie
+- **Nível de permissão:** Apenas usuários com `role: admin`
+
+## Parâmetros da Requisição
+
+### URL Parameters
+
+| Campo | Tipo   | Obrigatório | Validação            | Exemplo                      |
+| ----- | ------ | ----------- | -------------------- | ---------------------------- |
+| id    | string | Sim         | ID válido do MongoDB | `"66b9d4e1a0f3e6c4f4a21c8e"` |
+
+### Body (multipart/form-data)
+
+| Campo       | Tipo   | Obrigatório | Validação                                                                    | Exemplo                                                             |
+| ----------- | ------ | ----------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| name        | string | Não         | Texto simples                                                                | `"Marcos Silva"`                                                    |
+| cpf         | string | Não         | Exatamente 11 dígitos, válido, único no sistema                              | `"12345678910"`                                                     |
+| email       | string | Não         | Formato válido, único no sistema                                             | `"marcossilva@gmail.com"`                                           |
+| hourPrice   | number | Não         | Valor numérico maior que 0                                                   | `5.0`                                                               |
+| description | string | Não         | Texto simples                                                                | `"Faixa Preta 3º Dan. Com mais de 15 anos de experiência no judô."` |
+| modalities  | array  | Não         | IDs válidos (`ObjectId` do MongoDB), ao menos 1 modalidade ativa obrigatória | `["64f1b2a3c4d5e6f7890abc12"]`                                      |
+| image       | file   | Não         | Formatos permitidos: jpg, jpeg, png, gif. Tamanho máximo: **5MB**            | (arquivo .jpg, .jpeg, .png ou .gif)\*                               |
+
+**Exemplo de Body (form-data no Postman):**
+
+```
+name: Marcos Silva
+cpf: 12345678910
+email: marcossilva@gmail.com
+hourPrice: 5.0
+description: Faixa Preta 3º Dan. Com mais de 15 anos de experiência no judô.
+modalities[]: 64f1b2a3c4d5e6f7890abc12
+image: [arquivo .jpg, .jpeg, .png ou .gif]
+```
+
+## Resposta de Sucesso
+
+**Status:** `200 OK`
+
+```json
+{
+  "data": {
+    "_id": "66b9d4e1a0f3e6c4f4a21c8e",
+    "name": "Marcos Silva",
+    "cpf": "12345678910",
+    "email": "marcossilva@gmail.com",
+    "hourPrice": 5,
+    "description": "Faixa Preta 3º Dan. Com mais de 15 anos de experiência no judô.",
+    "modalities": [
+      {
+        "name": "Judô",
+        "description": "O Judô é uma arte marcial de origem japonesa",
+        "status": true
+      }
+    ],
+    "image": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABA...",
+    "status": true,
+    "updatedAt": "2025-09-15T18:00:00.000Z"
+  }
+}
+```
+
+## Respostas de Erro
+
+**Status:** `400 Bad Request` — ID inválido ou violação de regras de modalidades vinculadas a turmas
+
+```json
+{
+  "statusCode": 400,
+  "message": [
+    "Invalid id format",
+    "Teacher Marcos Silva must have the 64f1b2a3c4d5e6f7890abc12 modality to match his class registration"
+  ],
+  "error": "Bad Request"
+}
+```
+
+**Status:** `401 Unauthorized` — Token JWT ausente ou inválido
+
+```json
+{
+  "statusCode": 401,
+  "message": "Unauthorized"
+}
+```
+
+**Status:** `403 Forbidden` — Usuário não tem permissão (role diferente de `admin`)
+
+```json
+{
+  "statusCode": 403,
+  "message": "Forbidden resource"
+}
+```
+
+**Status:** `404 Not Found` — Professor ou modalidade não encontrada
+
+```json
+{
+  "statusCode": 404,
+  "message": "Teacher with id 66b9d4e1a0f3e6c4f4a21c8e not found"
+}
+```
+
+ou
+
+```json
+{
+  "statusCode": 404,
+  "message": "Modalities with id 64f1b2a3c4d5e6f7890abc12 not found"
+}
+```
+
+**Status:** `409 Conflict` — CPF ou E-mail já cadastrado
+
+```json
+{
+  "statusCode": 409,
+  "message": "CPF 12345678910 already exists"
+}
+```
+
+ou
+
+```json
+{
+  "statusCode": 409,
+  "message": "Email marcossilva@gmail.com already exists"
+}
+```
+
+## Observações
+- Máximo de **10 requisições por minuto** por IP
+- `cpf` e `email` devem ser **únicos no sistema**
+- `image` é armazenada no banco de dados como **Buffer**. Na resposta, é transformada em **Base64**
+- Não é permitido remover modalidades que estejam vinculadas a turmas ativas.
+- O professor deve possuir **ao menos uma modalidade ativa** vinculada.
+- Autenticação via **token JWT** armazenado em **cookie HTTP-only**.
+- Validações de campos e integridade são aplicadas antes da atualização.


### PR DESCRIPTION
## O que foi feito
Documentação detalhada de novos endpoints, fluxos e funcionalidades do módulo de professores:
- Cadastro de professores (`POST api/v1/teachers`)
- Listagem de professores (`GET api/v1/teachers`)
- Busca por professor específico (`GET api/v1/teachers/:id`)
- Atualização de professores (`PATCH api/v1/teachers/:id`)
- Exclusão lógica de professores (`DELETE api/v1/teachers/:id`)
- Relatório de professores em PDF (`GET api/v1/teachers/report`)

#### [Ticket Trello - Documentar módulo de professores](https://trello.com/c/yEpNT7am/55-documentar-m%C3%B3dulo-de-professores)